### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ slick-greeter (1.3.2+dfsg.1-2) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
   * Use canonical URL in Vcs-Git.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata
+    (already present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:37:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+slick-greeter (1.3.2+dfsg.1-2) UNRELEASED; urgency=medium
+
+  * Set field Upstream-Contact in debian/copyright.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:37:28 +0000
+
 slick-greeter (1.3.2+dfsg.1-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 slick-greeter (1.3.2+dfsg.1-2) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:37:28 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends:
  valac (>= 0.20.0),
  xvfb,
 Vcs-Browser: https://github.com/UbuntuBudgie/slick-greeter/tree/debian
-Vcs-Git: https://github.com/UbuntuBudgie/slick-greeter -b debian
+Vcs-Git: https://github.com/UbuntuBudgie/slick-greeter.git -b debian
 
 Package: slick-greeter
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,6 +2,7 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: slick-greeter
 Source: https://github.com/linuxmint/slick-greeter
 Files-Excluded: debian
+Upstream-Contact: Clement Lefebvre <root@linuxmint.com>
 
 Files: *
 Copyright: 2011-2013 Canonical Ltd

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,8 +1,6 @@
 ---
-Name: slick-greeter
 Homepage: https://github.com/linuxmint/slick-greeter/
 Bug-Database: https://github.com/linuxmint/slick-greeter
 Cite-As: "Distro agnostic slick looking LightDM Greeter"
-Contact: Clement Lefebvre <root@linuxmint.com>
 Repository: https://github.com/linuxmint/slick-greeter.git
 Repository-Browse: https://github.com/linuxmint/slick-greeter


### PR DESCRIPTION
Fix some issues reported by lintian
* Set field Upstream-Contact in debian/copyright.
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/slick-greeter/93c9abdf-9820-449a-9a73-10677edfee43.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/93c9abdf-9820-449a-9a73-10677edfee43/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/93c9abdf-9820-449a-9a73-10677edfee43/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/93c9abdf-9820-449a-9a73-10677edfee43/diffoscope)).
