### PR TITLE
Avoid explicitly specifying -Wl,--as-needed linker flag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+slick-greeter (1.5.9-2) UNRELEASED; urgency=medium
+
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 01 Aug 2022 08:54:11 -0000
+
 slick-greeter (1.5.9-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed -Wl,-O1
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 export DH_VERBOSE = 1
 


### PR DESCRIPTION

Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/slick-greeter/a85aa38e-1078-47ed-932b-d6d545b1c6d2.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a85aa38e-1078-47ed-932b-d6d545b1c6d2/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a85aa38e-1078-47ed-932b-d6d545b1c6d2/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a85aa38e-1078-47ed-932b-d6d545b1c6d2/diffoscope)).
