### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 slick-greeter (1.5.9-2) UNRELEASED; urgency=medium
 
   * Avoid explicitly specifying -Wl,--as-needed linker flag.
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on liblightdm-gobject-dev,
+      lightdm-vala and valac.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 01 Aug 2022 08:54:11 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -12,10 +12,10 @@ Build-Depends:
  gnome-common,
  libcanberra-dev,
  libgtk-3-dev,
- liblightdm-gobject-dev (>= 1.18.3) | liblightdm-gobject-1-dev (>= 1.4.0),
+ liblightdm-gobject-dev | liblightdm-gobject-1-dev (>= 1.4.0),
  libpixman-1-dev,
- lightdm-vala (>= 1.18.3) | liblightdm-gobject-1-dev (>= 1.4.0),
- valac (>= 0.20.0),
+ lightdm-vala | liblightdm-gobject-1-dev (>= 1.4.0),
+ valac,
  xvfb,
 Vcs-Browser: https://github.com/UbuntuBudgie/slick-greeter/tree/debian
 Vcs-Git: https://github.com/UbuntuBudgie/slick-greeter.git -b debian


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/slick-greeter/c6474281-d31f-490d-b2aa-a03ad1b8bce3.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/38/398f3bc8cd2db3eb72a9f3087f6f433e48dc93.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0c/e533987ca762baf974d41d95773b9c479482e0.debug

No differences were encountered between the control files of package \*\*slick-greeter\*\*
### Control files of package slick-greeter-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-0ce533987ca762baf974d41d95773b9c479482e0-] {+38398f3bc8cd2db3eb72a9f3087f6f433e48dc93+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c6474281-d31f-490d-b2aa-a03ad1b8bce3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c6474281-d31f-490d-b2aa-a03ad1b8bce3/diffoscope)).
